### PR TITLE
Add metric owner of Burrow in label

### DIFF
--- a/exporter/client.go
+++ b/exporter/client.go
@@ -41,7 +41,7 @@ type TopicsResp struct {
 	BurrowResp
 	Topics []string `json:"topics"`
 }
- 
+
 type ConsumerGroupTopicDetailsResp struct {
 	BurrowResp
 	Offsets []int64 `json:"offsets"`

--- a/exporter/client.go
+++ b/exporter/client.go
@@ -41,7 +41,7 @@ type TopicsResp struct {
 	BurrowResp
 	Topics []string `json:"topics"`
 }
-
+ 
 type ConsumerGroupTopicDetailsResp struct {
 	BurrowResp
 	Offsets []int64 `json:"offsets"`

--- a/exporter/client.go
+++ b/exporter/client.go
@@ -61,6 +61,7 @@ type ConsumerGroupStatus struct {
 	MaxLag     Partition   `json:"maxlag"`
 	Partitions []Partition `json:"partitions"`
 	TotalLag   int64       `json:"totallag"`
+	Owner      string      `json:"owner"`
 }
 
 type Partition struct {
@@ -70,6 +71,7 @@ type Partition struct {
 	Start      Offset `json:"start"`
 	End        Offset `json:"end"`
 	CurrentLag int64  `json:"current_lag"`
+	Owner      string `json:"owner"`
 }
 
 type ConsumerGroupStatusResp struct {

--- a/exporter/collector.go
+++ b/exporter/collector.go
@@ -19,7 +19,7 @@ var Status = map[string]int{
 	"STOP":     5,
 	"STALL":    6,
 	"REWIND":   7,
-} 
+}
 
 var (
 	kafkaConsumerPartitionLagDesc           = prometheus.NewDesc("kafka_burrow_partition_lag", "The lag of the latest offset commit on a partition as reported by burrow.", []string{"cluster", "group", "topic", "owner", "partition"}, nil)

--- a/exporter/collector.go
+++ b/exporter/collector.go
@@ -22,10 +22,10 @@ var Status = map[string]int{
 }
 
 var (
-	kafkaConsumerPartitionLagDesc           = prometheus.NewDesc("kafka_burrow_partition_lag", "The lag of the latest offset commit on a partition as reported by burrow.", []string{"cluster", "group", "topic", "partition"}, nil)
-	kafkaConsumerPartitionCurrentOffsetDesc = prometheus.NewDesc("kafka_burrow_partition_current_offset", "The latest offset commit on a partition as reported by burrow.", []string{"cluster", "group", "topic", "partition"}, nil)
-	kafkaConsumerPartitionCurrentStatusDesc = prometheus.NewDesc("kafka_burrow_partition_status", "The status of a partition as reported by burrow.", []string{"cluster", "group", "topic", "partition"}, nil)
-	kafkaConsumerPartitionMaxOffsetDesc     = prometheus.NewDesc("kafka_burrow_partition_max_offset", "The log end offset on a partition as reported by burrow.", []string{"cluster", "group", "topic", "partition"}, nil)
+	kafkaConsumerPartitionLagDesc           = prometheus.NewDesc("kafka_burrow_partition_lag", "The lag of the latest offset commit on a partition as reported by burrow.", []string{"cluster", "group", "topic", "owner", "partition"}, nil)
+	kafkaConsumerPartitionCurrentOffsetDesc = prometheus.NewDesc("kafka_burrow_partition_current_offset", "The latest offset commit on a partition as reported by burrow.", []string{"cluster", "group", "topic", "owner", "partition"}, nil)
+	kafkaConsumerPartitionCurrentStatusDesc = prometheus.NewDesc("kafka_burrow_partition_status", "The status of a partition as reported by burrow.", []string{"cluster", "group", "topic", "owner", "partition"}, nil)
+	kafkaConsumerPartitionMaxOffsetDesc     = prometheus.NewDesc("kafka_burrow_partition_max_offset", "The log end offset on a partition as reported by burrow.", []string{"cluster", "group", "topic", "owner", "partition"}, nil)
 	kafkaConsumerTotalLagDesc               = prometheus.NewDesc("kafka_burrow_total_lag", "The total amount of lag for the consumer group as reported by burrow.", []string{"cluster", "group"}, nil)
 	kafkaConsumerStatusDesc                 = prometheus.NewDesc("kafka_burrow_status", "The status of a partition as reported by burrow.", []string{"cluster", "group"}, nil)
 	kafkaTopicPartitionOffsetDesc           = prometheus.NewDesc("kafka_burrow_topic_partition_offset", "The latest offset on a topic's partition as reported by burrow.", []string{"cluster", "topic", "partition"}, nil)
@@ -55,7 +55,7 @@ func (c *Collector) processGroup(cluster, group string) (metrics []prometheus.Me
 
 	for _, partition := range resp.Status.Partitions {
 
-		labels := append(commonLabels, partition.Topic, strconv.Itoa(int(partition.Partition)))
+		labels := append(commonLabels, partition.Topic, partition.Owner, strconv.Itoa(int(partition.Partition)))
 
 		if !c.skipPartitionLag {
 			metric, err := prometheus.NewConstMetric(
@@ -251,3 +251,4 @@ func NewCollector(burrowUrl string, apiVersion int, disabledMetrics string) *Col
 		skipTopicPartitionOffset:   disabledMetricsSet["topic-partition-offset"],
 	}
 }
+

--- a/exporter/collector.go
+++ b/exporter/collector.go
@@ -19,7 +19,7 @@ var Status = map[string]int{
 	"STOP":     5,
 	"STALL":    6,
 	"REWIND":   7,
-}
+} 
 
 var (
 	kafkaConsumerPartitionLagDesc           = prometheus.NewDesc("kafka_burrow_partition_lag", "The lag of the latest offset commit on a partition as reported by burrow.", []string{"cluster", "group", "topic", "owner", "partition"}, nil)


### PR DESCRIPTION
This metric that return in the endpoint of burrow, show the consumer owner of Partition of each topic. 

The metric appear like this in the label: 
(...){(...), owner="/10.0.100.10", (...)}